### PR TITLE
Fix unicode problem when saving models.

### DIFF
--- a/skil/context.py
+++ b/skil/context.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+import sys
 import uuid
 
 import keras

--- a/skil/context.py
+++ b/skil/context.py
@@ -64,6 +64,9 @@ class SkilContext(object):
         if isinstance(model, keras.models.Model):
             models_path = self._models_path()
             file_path = os.path.join(models_path, str(uuid.uuid1()) + '.h5')
+            
+            if isinstance(file_path, unicode):
+                file_path = file_path.encode(sys.getfilesystemencoding())
 
             model.save(file_path)
 


### PR DESCRIPTION
If you give a unicode object to Model#save you will get the following error:

```
Traceback (most recent call last):
  File "/var/folders/d6/q7jxwv353qx9h_2gth8szwg80000gn/T/zeppelin_pyspark-625805243906920828.py", line 367, in <module>
    raise Exception(traceback.format_exc())
Exception: Traceback (most recent call last):
  File "/var/folders/d6/q7jxwv353qx9h_2gth8szwg80000gn/T/zeppelin_pyspark-625805243906920828.py", line 360, in <module>
    exec(code, _zcUserQueryNameSpace)
  File "<stdin>", line 2, in <module>
  File "/opt/skil/miniconda/lib/python2.7/site-packages/keras/engine/network.py", line 1090, in save
    save_model(self, filepath, overwrite, include_optimizer)
  File "/opt/skil/miniconda/lib/python2.7/site-packages/keras/engine/saving.py", line 379, in save_model
    f = h5dict(filepath, mode='w')
  File "/opt/skil/miniconda/lib/python2.7/site-packages/keras/utils/io_utils.py", line 197, in __init__
    'Received: {}.'.format(type(path)))
TypeError: Required Group, str or dict. Received: <type 'unicode'>.
```

So this change encodes the file into a str before calling save if necessary.