### PR TITLE
Fix exception when creating model using get_model_by_id

### DIFF
--- a/skil/models.py
+++ b/skil/models.py
@@ -79,8 +79,8 @@ class Model:
                                                             id)
             self.name = model_entity.model_name
             self.version = model_entity.model_version
-            self.model_path = self.skil.get_model_path(model_file_name)
-            self.model = None
+            self.model_path = model_entity.uri
+            self.model = model_entity
 
     def delete(self):
         """Deletes the model


### PR DESCRIPTION
get_model_by_id passes create=False which throws an undefined variable error on model_file_name since it doesn't exist in that branch.  Since the model is specified by ID, it must already exist and be uploaded, so the uploading feature can be skipped.  The change here allows it to work.