### PR TITLE
Fixed get_service_by_id 

### DIFF
--- a/skil/experiments.py
+++ b/skil/experiments.py
@@ -68,7 +68,13 @@ class Experiment:
                 experiment_id
             )
             self.experiment_entity = experiment_entity
-            self.work_space = work_space
+            
+            if not work_space:
+                workspace_id = experiment_entity.model_history_id
+                self.work_space = get_workspace_by_id(skil_server, workspace_id)
+            else:
+                self.work_space = work_space
+                
             self.id = experiment_id
             self.name = experiment_entity.experiment_name
 

--- a/skil/models.py
+++ b/skil/models.py
@@ -84,11 +84,11 @@ class Model(object):
             self.skil = self.work_space.skil
             assert model_id is not None
             self.id = model_id
-            model_entity = self.skil.api.get_model_instance(self.skil.server_id,
+            model_instance = self.skil.api.get_model_instance(self.skil.server_id,
                                                             self.id)
-            self.name = model_entity.model_name
-            self.version = model_entity.model_version
-            self.model_path = model_entity.uri
+            self.name = model_instance.model_name
+            self.version = model_instance.model_version
+            self.model_path = model_instance.uri
 
         self.service = None
 

--- a/skil/services.py
+++ b/skil/services.py
@@ -207,7 +207,7 @@ class Service(object):
         cv2.imwrite(temp_path, image)
         url = 'http://{}/endpoints/{}/model/{}/v{}/detectobjects'.format(
             self.skil.config.host,
-            self.model.deployment.name,
+            self.deployment.name,
             self.model.name,
             self.model.version
         )
@@ -254,15 +254,16 @@ def get_service_by_id(skil_server, experiment_id, model_id, deployment_id, model
         deployment_id: string, deployment ID
         model_entity_id: optional string, ModelEntity ID of the deployed model
     """
-    deployment = skil.deployments.get_deployment_by_id(
-        skil_server, deployment_id)
-    experiment = get_experiment_by_id(skil_server, experiment_id)
-    model = skil.models.get_model_by_id(experiment, model_id)
+    deployment = skil.deployments.get_deployment_by_id(skil_server, deployment_id)
+    experiment = skil.experiments.get_experiment_by_id(skil_server, experiment_id)
+    model      = skil.models.get_model_by_id(experiment, model_id)
 
     if model_entity_id:
-        model_entity = skil_client.ModelEntity(id=model_entity_id)
+        model_entity = skil_server.api.get_model_details(deployment_id, model_entity_id)
     else:
-        model_entity = None
+        model_entities = skil_server.api.models(deployment_id)
+        # retrieve model_entity that matches model name
+        model_entity = next(entity for entity in model_entities if entity.name == model.name)
 
     return Service(
         skil=skil_server,

--- a/skil/utils/io.py
+++ b/skil/utils/io.py
@@ -13,7 +13,7 @@ def serialize_config(config, file_name, file_format):
     """
     with open(file_name, 'w') as f:
         if file_format == 'json':
-            json.dump(config, f)
+            json.dump(config, f, indent=4, sort_keys=True)
         elif file_format == 'yaml':
             yaml.dump(config, f)
         else:


### PR DESCRIPTION
This PR based on issues: #80, #81, and #82.

**Fixed get_experiment_by_id**, in services.py
```python
experiment = skil.experiments.get_experiment_by_id(skil_server, experiment_id)
```
**Added work_space initialization to experiments**, in experiments.py
```python
if not work_space:
    workspace_id = experiment_entity.model_history_id
    self.work_space = get_workspace_by_id(skil_server, workspace_id)
```
**Retrieved model_entity value**, in services.py
```python
if model_entity_id:
    model_entity = skil_server.api.get_model_details(deployment_id, model_entity_id)
else:
    model_entities = skil_server.api.models(deployment_id)
    # retrieve model_entity that matches model name
    model_entity = next(entity for entity in model_entities if entity.name == model.name)
```
**Made pretty JSON dump**, in utils.io.py
```python
with open(file_name, 'w') as f:
    if file_format == 'json':
        json.dump(config, f, indent=4, sort_keys=True)
```
**Changed variable name from model_entity to model_instance**, in models.py

 As it might be confused to the actual model_entity: `skil_server.api.get_model_details()`

```python
model_instance = self.skil.api.get_model_instance(self.skil.server_id,  self.id)
self.name = model_instance.model_name
self.version = model_instance.model_version
self.model_path = model_instance.uri

```

